### PR TITLE
Viaje plus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+*.code-workspace

--- a/src/Tarjeta.php
+++ b/src/Tarjeta.php
@@ -3,17 +3,18 @@
 namespace TrabajoTarjeta;
 
 class Tarjeta implements TarjetaInterface {
-    protected $saldo;
+    protected $saldo = 0; // float
+    protected $plus = 0; // int
 
     public function recargar($monto) {
-      // Esto esta hecho mal a proposito.
       if ($monto == 10 || $monto == 20 || $monto == 30 || $monto == 50 || $monto == 100 || $monto == 510.15 || $monto == 962.59) {
+        $monto -= ($this->plus * 14.8); // el costo de los viajes plus siempre sera 14.8, independientemente de su franquicia
         $this->saldo += $monto;
+        $this->plus = 0;
         if ($monto == 510.15) $this->saldo += 81.93;
         if ($monto == 962.59) $this->saldo += 221.58;
         return true;
       }
-
       return false;
     }
 
@@ -24,6 +25,16 @@ class Tarjeta implements TarjetaInterface {
      */
     public function obtenerSaldo() {
       return $this->saldo;
+    }
+
+    public function pagar($valor) {
+      if ($this->saldo < 0) return false; // no se toleraran valores negativos
+      if ($this->saldo < $valor) {
+        if ($this->plus > 1) return false; // como maximo podra adeudar 2 viajes plus
+        $this->plus ++;
+      }
+      else $this->saldo -= $valor;
+      return true;
     }
 
 }

--- a/src/TarjetaInterface.php
+++ b/src/TarjetaInterface.php
@@ -13,13 +13,25 @@ interface TarjetaInterface {
      *   Devuelve TRUE si el monto a cargar es válido, o FALSE en caso de que no
      *   sea valido.
      */
-    public function recargar($monto);
 
+    public function recargar($monto);
     /**
      * Devuelve el saldo que le queda a la tarjeta.
      *
      * @return float
      */
+
     public function obtenerSaldo();
+
+    /**
+     * Si el saldo es suficiente, lo resta por pagar un boleto del valor pedido
+     * Si el saldo es insuficiente, suma un viaje plus de deuda, siendo el maximo 2
+     * 
+     * @param float $valor
+     * 
+     * @return bool
+     * Devuelve TRUE si puede pagar (si el saldo es suficiente o se abona con plus), o FALSE en caso contrario
+     */
+    public function pagar($valor);
 
 }

--- a/tests/TarjetaTest.php
+++ b/tests/TarjetaTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 class TarjetaTest extends TestCase {
 
     /**
-     * Comprueba que la tarjeta aumenta su saldo cuando se carga saldo válido.
+     * Comprueba que la tarjeta aumenta su saldo cuando se carga cualquiera de los montos validos.
      */
     public function testCargaSaldo() {
         $tarjeta = new Tarjeta;
@@ -17,6 +17,21 @@ class TarjetaTest extends TestCase {
 
         $this->assertTrue($tarjeta->recargar(20));
         $this->assertEquals($tarjeta->obtenerSaldo(), 30);
+
+        $this->assertTrue($tarjeta->recargar(30));
+        $this->assertEquals($tarjeta->obtenerSaldo(), 60);
+
+        $this->assertTrue($tarjeta->recargar(50));
+        $this->assertEquals($tarjeta->obtenerSaldo(), 110);
+
+        $this->assertTrue($tarjeta->recargar(100));
+        $this->assertEquals($tarjeta->obtenerSaldo(), 210);
+
+        $this->assertTrue($tarjeta->recargar(510.15));
+        $this->assertEquals($tarjeta->obtenerSaldo(), 802.08); // se suma el beneficio tambien
+
+        $this->assertTrue($tarjeta->recargar(962.59));
+        $this->assertEquals($tarjeta->obtenerSaldo(), 1986.25); // se suma el beneficio tambien
     }
 
     /**
@@ -27,5 +42,36 @@ class TarjetaTest extends TestCase {
 
       $this->assertFalse($tarjeta->recargar(15));
       $this->assertEquals($tarjeta->obtenerSaldo(), 0);
-  }
+    }
+
+    /**
+     * Comprueba que el saldo reste al pagar un viaje.
+     * Ademas prueba el correcto funcionamiento del concepto 'viaje plus' al pagar y recargar
+     */
+    public function testViajes() {
+        $tarjeta = new Tarjeta;
+
+        $this->assertTrue($tarjeta->recargar(20)); // saldo inicial: 20
+        $this->assertTrue($tarjeta->pagar(14.8));
+        $this->assertEquals($tarjeta->obtenerSaldo(), 5.2); // el saldo fue restado
+
+        $this->assertTrue($tarjeta->pagar(14.8)); // se adeuda un viaje plus
+        $this->assertEquals($tarjeta->obtenerSaldo(), 5.2); // pero el saldo no varia
+        $this->assertTrue($tarjeta->recargar(10)); // se recargan 10
+        $this->assertEquals($tarjeta->obtenerSaldo(), 0.4); // pero se comprueba que la deuda de 1 plus fue saldada en la recarga
+
+        $this->assertTrue($tarjeta->pagar(14.8)); // como el saldo es positivo sin plus pendientes se puede volver a adeudar
+        $this->assertTrue($tarjeta->pagar(14.8)); // ahora se adeudan 2 viajes plus
+        $this->assertEquals($tarjeta->obtenerSaldo(), 0.4); // sin variar el saldo
+        $this->assertFalse($tarjeta->pagar(14.8)); // y como ya no se puede adeudar mas, no puede pagar otro viaje, aunque el saldo sea positivo
+
+        $this->assertTrue($tarjeta->recargar(10)); // si se recarga poco con tanta deuda
+        $this->assertEquals($tarjeta->obtenerSaldo(), -19.2); // el saldo quedara negativo porque se saldan los plus
+        $this->assertFalse($tarjeta->pagar(14.8)); // pero no se podra viajar hasta saldar la deuda
+
+        $this->assertTrue($tarjeta->recargar(50)); // se salda la deuda
+        $this->assertTrue($tarjeta->pagar(14.8)); // y se puede volver a viajar
+        $this->assertEquals($tarjeta->obtenerSaldo(), 16); // saldo final: 16
+    }
+
 }


### PR DESCRIPTION
Agrego el concepto de plus. No afecta el comportamiento de Colectivo (ni a pagarCon). Se resta la deuda al cargar la tarjeta, no al pagar un nuevo viaje. Esto posibilita que haya saldo negativo si no se carga lo suficiente, aunque esta previsto que no se pueda viajar en este caso.